### PR TITLE
Fix: incorrect transaction date caused by timezone offset + test coverage

### DIFF
--- a/src/features/transactions/lib/__tests__/formatTransactionDate.test.ts
+++ b/src/features/transactions/lib/__tests__/formatTransactionDate.test.ts
@@ -1,0 +1,23 @@
+import { formatTransactionDate } from "../formatTransactionDate";
+
+describe("formatTransactionDate", () => {
+  it("formats date correctly without timezone issues", () => {
+    const input = new Date().toISOString().split("T")[0];
+    const result = formatTransactionDate(input);
+
+    const [year, month, day] = input.split("-");
+    const expected = `${month}-${day}-${year}`;
+
+    expect(result).toBe(expected);
+  });
+
+  it("formats 2025-06-26 correctly into MM-dd-yyyy", () => {
+    const result = formatTransactionDate("2025-06-26");
+    expect(result).toBe("06-26-2025");
+  });
+
+  it("formats 2024-02-29 correctly (leap year)", () => {
+    const result = formatTransactionDate("2024-02-29");
+    expect(result).toBe("02-29-2024");
+  });
+});

--- a/src/features/transactions/lib/formatTransactionDate.ts
+++ b/src/features/transactions/lib/formatTransactionDate.ts
@@ -1,0 +1,6 @@
+import { format, parse } from "date-fns";
+
+export function formatTransactionDate(input: string): string {
+  const parsed = parse(input, "yyyy-MM-dd", new Date());
+  return format(parsed, "MM-dd-yyyy");
+}

--- a/src/features/transactions/ui/TransactionForm.tsx
+++ b/src/features/transactions/ui/TransactionForm.tsx
@@ -1,12 +1,12 @@
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
-import { format, parse } from "date-fns";
 
 import Button from "../../../shared/ui/Button";
 import FormField from "../../../shared/ui/FormField";
 import useTransactionStore from "../model/useTransactionStore";
 import { TransactionType } from "../model/types";
 import { categories } from "../../../shared/constants/categories";
+import { formatTransactionDate } from "../lib/formatTransactionDate";
 
 const validCategoryValues = categories.map((category) => category.value);
 
@@ -41,12 +41,7 @@ const TransactionForm = () => {
       validationSchema={TransactionSchema}
       onSubmit={(values, { setSubmitting, resetForm }) => {
         setTimeout(() => {
-          const parsedDate = parse(values.date, "yyyy-MM-dd", new Date());
-          const formattedDate = format(parsedDate, "MM-dd-yyyy");
-
-          console.log("formattedDate: ", formattedDate);
-          console.log("date: ", new Date().toISOString().split("T")[0]);
-          console.log("values.date: ", values.date);
+          const formattedDate = formatTransactionDate(values.date);
 
           const newTransaction = {
             ...values,

--- a/src/features/transactions/ui/TransactionForm.tsx
+++ b/src/features/transactions/ui/TransactionForm.tsx
@@ -1,6 +1,6 @@
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
-import { format } from "date-fns";
+import { format, parse } from "date-fns";
 
 import Button from "../../../shared/ui/Button";
 import FormField from "../../../shared/ui/FormField";
@@ -41,7 +41,12 @@ const TransactionForm = () => {
       validationSchema={TransactionSchema}
       onSubmit={(values, { setSubmitting, resetForm }) => {
         setTimeout(() => {
-          const formattedDate = format(new Date(values.date), "MM-dd-yyyy");
+          const parsedDate = parse(values.date, "yyyy-MM-dd", new Date());
+          const formattedDate = format(parsedDate, "MM-dd-yyyy");
+
+          console.log("formattedDate: ", formattedDate);
+          console.log("date: ", new Date().toISOString().split("T")[0]);
+          console.log("values.date: ", values.date);
 
           const newTransaction = {
             ...values,


### PR DESCRIPTION
### 🐛 Bug Fix
This PR resolves an issue where transactions submitted with a date (e.g. "2025-06-26") were being stored one day earlier due to implicit timezone conversion when using `new Date()`.

### ♻️ Refactor
- Extracted the date formatting logic into a reusable utility function located at:
  `features/transactions/lib/formatTransactionDate.ts`

### ✅ Test Coverage
- Added unit tests for `formatTransactionDate` to ensure consistent output and to prevent regressions.
- Test cases include:
  - Hardcoded known date values
  - Leap year scenarios
  - Simulated input from `<input type="date" />`

### 🧠 Context
The root of the bug was JS interpreting `new Date("YYYY-MM-DD")` as UTC, which caused the day to shift depending on the user's local timezone (e.g. UTC-3 resulted in the previous day being stored).

---

✅ Everything tested manually and covered with unit tests.